### PR TITLE
Avoid mutating rectangle data to initial data drawing

### DIFF
--- a/dev/src/DrawCanvas/DrawCanvas.js
+++ b/dev/src/DrawCanvas/DrawCanvas.js
@@ -192,10 +192,12 @@ class DrawCanvas extends React.PureComponent {
             let shape = canvasHandler.getTool(el);
             this.tool = tools[shape];
             this.tool.ctx = this.ctx;
+            // avoid mutate initial data;
+            let newData;
             if (el.startsWith('Rectan')) {
-                data[el] = [data[el][TOP_LEFT], data[el][BOTTOM_RIGHT]];
+                newData[el] = [data[el][TOP_LEFT], data[el][BOTTOM_RIGHT]];
             }
-            let elPoints = data[el];
+            let elPoints = el.startsWith('Rectan') ? newData[el] : data[el];
             if (el.startsWith('Line') || el.startsWith('Arrang')) {
                 elPoints.forEach((point) => {
                     this.tool.draw({ x: point[START][X], y: point[START][Y] }, { x: point[END][X], y: point[END][Y] }, false, {


### PR DESCRIPTION
Avoiding mutating initial data, so if we load a old data we don't break the redraw.